### PR TITLE
Use <= for bitset epoch comparisons

### DIFF
--- a/relaxed_concurrent_fifo/block_based_queue.h
+++ b/relaxed_concurrent_fifo/block_based_queue.h
@@ -120,7 +120,7 @@ private:
 	static_assert(sizeof(block_t) == CELLS_PER_BLOCK * sizeof(T) + sizeof(header_t));
 
 	// Doing it like this avoids having to have a special case for first-time initialization, while only claiming a block on first use.
-	static inline block_t dummy_block{ header_t{epoch_to_header(0xffff'ffffull)}, {} };
+	static inline block_t dummy_block{ header_t{epoch_to_header(0x1000'0000ull)}, {} };
 
 	using window_t = window<block_t, blocks_per_window, BITSET_T>;
 	std::unique_ptr<window_t[]> buffer;
@@ -190,6 +190,10 @@ public:
 
 		friend block_based_queue;
 
+		static constexpr bool epoch_valid(std::uint32_t check, std::uint32_t curr) {
+			return (curr - check) < std::numeric_limits<std::uint32_t>::max() / 2;
+		}
+
 		int random_bit_index() {
 			return std::uniform_int_distribution<int>(0, blocks_per_window - 1)(rng);
 		}
@@ -234,16 +238,11 @@ public:
 						if (!new_window.filled_set.any(write_epoch, std::memory_order_relaxed)) {
 							return false;
 						}
-						// TODO: This should be simplifiable? Spurious block claims only occur when force-moving.
+
 						// Before we force-move the write window, there might be unclaimed blocks in the current one.
 						// We need to make sure we clean those up BEFORE we move the write window in order to prevent
 						// the read window from being moved before all blocks have either been claimed or invalidated.
-						std::uint64_t next_ei = epoch_to_header(write_epoch + 1);
 						new_window.filled_set.set_epoch_if_empty(write_epoch, std::memory_order_relaxed);
-						for (std::size_t i = 0; i < blocks_per_window; i++) {
-							std::uint64_t ei = epoch_to_header(write_epoch); // All empty with current epoch.
-							new_window.blocks[i].header.epoch_and_indices.compare_exchange_strong(ei, next_ei, std::memory_order_relaxed);
-						}
 						fifo.write_window.compare_exchange_strong(write_window, write_window + 1, std::memory_order_relaxed);
 #if BBQ_LOG_WINDOW_MOVE
 						std::cout << "Write force move " << (write_window + 1) << std::endl;
@@ -276,7 +275,7 @@ public:
 			bool failure = true;
 			while (failure) {
 				T old = 0;
-				while (get_epoch(ei) != write_epoch || (index = get_write_index(ei)) == CELLS_PER_BLOCK
+				while (!epoch_valid(get_epoch(ei), write_epoch) || (index = get_write_index(ei)) == CELLS_PER_BLOCK
 					|| !write_block->cells[index].compare_exchange_weak(old, t, std::memory_order_relaxed)) {
 					if (!claim_new_block_write()) {
 						return false;
@@ -304,7 +303,7 @@ public:
 			std::uint64_t index;
 
 			while (true) {
-				if (get_epoch(ei) == read_epoch) {
+				if (epoch_valid(get_epoch(ei), read_epoch)) {
 					if ((index = get_read_index(ei)) + 1 == get_write_index(ei)) {
 						if (header->epoch_and_indices.compare_exchange_weak(ei, epoch_to_header(read_epoch + 1), std::memory_order_acquire, std::memory_order_relaxed)) {
 							window_t& window = fifo.index_to_window(read_window);

--- a/relaxed_concurrent_fifo/block_based_queue.h
+++ b/relaxed_concurrent_fifo/block_based_queue.h
@@ -114,7 +114,7 @@ private:
 	static_assert(std::is_trivial_v<block_t>);
 
 	// Doing it like this avoids having to have a special case for first-time initialization, while only claiming a block on first use.
-	static inline std::atomic_uint64_t dummy_block_value{ epoch_to_header(0xffff'ffffull) };
+	static inline std::atomic_uint64_t dummy_block_value{ epoch_to_header(0x1000'0000ull) };
 	static inline block_t dummy_block{ reinterpret_cast<std::byte*>(&dummy_block_value) };
 
 	atomic_bitset<BITSET_T> filled_set;
@@ -228,6 +228,10 @@ public:
 
 		friend block_based_queue;
 
+		static constexpr bool epoch_valid(std::uint32_t check, std::uint32_t curr) {
+			return (curr - check) < std::numeric_limits<std::uint32_t>::max() / 2;
+		}
+
 		int random_bit_index() {
 			// TODO: Probably want to store this somewhere.
 			return std::uniform_int_distribution(0, static_cast<int>(fifo.blocks_per_window - 1))(rng);
@@ -273,16 +277,11 @@ public:
 						if (!fifo.filled_set.any(write_window_index, write_epoch, std::memory_order_relaxed)) {
 							return false;
 						}
-						// TODO: This should be simplifiable? Spurious block claims only occur when force-moving.
+
 						// Before we force-move the write window, there might be unclaimed blocks in the current one.
 						// We need to make sure we clean those up BEFORE we move the write window in order to prevent
 						// the read window from being moved before all blocks have either been claimed or invalidated.
-						std::uint64_t next_ei = epoch_to_header(write_epoch + 1);
 						fifo.filled_set.set_epoch_if_empty(write_window_index, write_epoch, std::memory_order_relaxed);
-						for (std::size_t i = 0; i < fifo.blocks_per_window; i++) {
-							std::uint64_t ei = epoch_to_header(write_epoch); // All empty with current epoch.
-							fifo.get_block(write_window_index, i).get_header().compare_exchange_strong(ei, next_ei, std::memory_order_relaxed);
-						}
 						fifo.write_window.compare_exchange_strong(write_window, write_window + 1, std::memory_order_relaxed);
 #if BBQ_LOG_WINDOW_MOVE
 						std::cout << "Write force move " << (write_window + 1) << std::endl;
@@ -315,7 +314,7 @@ public:
 			bool failure = true;
 			while (failure) {
 				T old = 0;
-				while (get_epoch(ei) != write_epoch || (index = get_write_index(ei)) == fifo.cells_per_block
+				while (!epoch_valid(get_epoch(ei), write_epoch) || (index = get_write_index(ei)) == fifo.cells_per_block
 					|| !write_block.get_cell(index).compare_exchange_weak(old, t, std::memory_order_relaxed)) {
 					if (!claim_new_block_write()) {
 						return false;
@@ -343,7 +342,7 @@ public:
 			std::uint64_t index;
 
 			while (true) {
-				if (get_epoch(ei) == read_epoch) {
+				if (epoch_valid(get_epoch(ei), read_epoch)) {
 					if ((index = get_read_index(ei)) + 1 == get_write_index(ei)) {
 						if (header->compare_exchange_weak(ei, epoch_to_header(read_epoch + 1), std::memory_order_acquire, std::memory_order_relaxed)) {
 							fifo.filled_set.reset(read_window, fifo.block_index(read_window, read_block), read_epoch, std::memory_order_relaxed);


### PR DESCRIPTION
Intention is to make force-moving significantly faster.

Considerations:
- Regular inner-block ops do not update the epoch, try that instead (better for correctness, performance?)
- Avoiding resetting both kinds of epochs possible IF additional check after write claim?